### PR TITLE
외부API용 Mock API 개발

### DIFF
--- a/src/main/java/com/kenny/futurewebclientpoc/external/ExternalMockController.java
+++ b/src/main/java/com/kenny/futurewebclientpoc/external/ExternalMockController.java
@@ -1,4 +1,25 @@
 package com.kenny.futurewebclientpoc.external;
 
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@RestController
+@Slf4j
 public class ExternalMockController {
+
+    @GetMapping("/external/mock_api")
+    public String getTimeStamp() {
+        try {
+            Thread.sleep(10000L);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+        log.warn(" # External Mock API Timestamp : {}", LocalDateTime.now());
+        return LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME);
+    }
 }


### PR DESCRIPTION
## What?
- ExternalMockController 클래스 개발 : /external/mock_api 추가하고, 호출되면 10초 동안 대기했다가 타임스탬프 문자열을 리턴하도록 함

## Why?
- 응답시간이 오래걸리는 외부API 호출상황을 가정하기 위함