### PR TITLE
feat: tocmat thread metric 작업 및 WebClient 커스텀로직 삭제

### DIFF
--- a/src/main/java/com/kenny/futurewebclientpoc/config/WebConfig.java
+++ b/src/main/java/com/kenny/futurewebclientpoc/config/WebConfig.java
@@ -16,12 +16,13 @@ import reactor.netty.resources.ConnectionProvider;
 @Slf4j
 public class WebConfig {
 
-    @Bean
-    public WebClient.Builder webClientBuilder() {
-        log.warn("# WebClient.Builder Bean Creation");
-
-        return WebClient.builder();
-    }
+// WebClient.builder를 custom 하게되면, Spring Boot AutoConfiguration을 통한 metric 수집을 못해서 일단 막아둠
+//    @Bean
+//    public WebClient.Builder webClientBuilder() {
+//        log.warn("# WebClient.Builder Bean Creation");
+//
+//        return WebClient.builder();
+//    }
 
 //    @Bean
 //    public WebClient webClient(final MeterRegistry meterRegistry) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,8 @@
+server:
+  tomcat:
+    mbeanregistry:
+      enabled: true   # actuator에서 tomcat.threads.xxx 메트릭을 확인하기 위한 옵션
+
 management:
   endpoints:
     web:


### PR DESCRIPTION
1. tomcat.threads 메트릭을 수집하기 위해 tomcat.mbeanregistry 활성화
2. WebClient.builder 커스텀 빈 등록 로직 삭제 : 커스텀의 경우 metric 수집 구현체가 바뀌어서 메트릭이 수집 안되는 현상으로 인해

issue: REQ-4